### PR TITLE
Add function to normalize word separators in flags

### DIFF
--- a/cmd/player.go
+++ b/cmd/player.go
@@ -24,7 +24,7 @@ var playerCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(playerCmd)
 
-	playerCmd.Flags().BoolP("one-line", "o", false, "Output without Bubble Tea on one line")
+	playerCmd.Flags().BoolP("oneline", "o", false, "Output playback data on one line")
 	playerCmd.Flags().BoolP("no-progress", "", false, "Do not include progress bar")
 }
 
@@ -77,12 +77,12 @@ func inlineSongLoop(token *oauth2.Token, noProgress bool) {
 		output = fmt.Sprintf("󰝚  %s - %s", playerState.Item.Name, playerState.Item.Artists[0].Name)
 	}
 
-  if playerState.Item != nil && !noProgress {
-    output = fmt.Sprintf("%s | %s", output, progressBar(playerState))
-  }
+	if playerState.Item != nil && !noProgress {
+		output = fmt.Sprintf("%s | %s", output, progressBar(playerState))
+	}
 
-  fmt.Println(output)
-  os.Exit(0)
+	fmt.Println(output)
+	os.Exit(0)
 }
 
 type model struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"strings"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -30,12 +32,23 @@ func Execute() {
 	}
 }
 
+func wordSepNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	from := []string{"_", ".", "-"}
+	to := ""
+	for _, sep := range from {
+		name = strings.Replace(name, sep, to, -1)
+	}
+	return pflag.NormalizedName(name)
+}
+
 func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.gosp.yaml)")
+
+	rootCmd.SetGlobalNormalizationFunc(wordSepNormalizeFunc)
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.


### PR DESCRIPTION
This allows for flags to be defined with underscores, periods, or hyphens.

For example, the following flags are equivalent:

  --one-line
  --one_line
  --one.line
  --one--line