### PR TITLE
Add shuffle sub-command to player

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ track.
 - `toggle` - Toggle between play and pause states
 - `next` - Skip to the next track
 - `prev` - Skip to the previous track
+- `shuffle` - Toggle shuffle state
 
 **Flags**
 - `--one-line` - show playing data in one line (works well with status bars)

--- a/cmd/player/shuffle.go
+++ b/cmd/player/shuffle.go
@@ -1,0 +1,46 @@
+package player
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/Esteban-Bermudez/spotgo/cmd/connect"
+	"github.com/spf13/cobra"
+	"github.com/zmb3/spotify/v2"
+)
+
+var playerShuffleCmd = &cobra.Command{
+	Use:   "shuffle",
+	Short: "Toggle shuffle on Spotify",
+	Long:  `Toggle between shuffle states on a Spotify playback session`,
+	Run:   spotifyShuffle,
+}
+
+func init() {
+	playerCmd.AddCommand(playerShuffleCmd)
+}
+
+func spotifyShuffle(cmd *cobra.Command, args []string) {
+	token, err := connect.LoadOAuthToken()
+	if err != nil {
+		log.Fatal("Error loading token, Run `spotgo connect` to connect to Spotify")
+	}
+
+	client := spotify.New(connect.Auth.Client(context.Background(), token))
+
+	playerState, err := client.PlayerState(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	shuffleState := !playerState.ShuffleState
+
+	client.Shuffle(context.Background(), shuffleState)
+
+	if shuffleState {
+		fmt.Println("Enabled shuffle")
+	} else {
+		fmt.Println("Disabled shuffle")
+	}
+}


### PR DESCRIPTION
This toggles between the shuffle states on a Spotify playback session.