### PR TITLE
Add scroll option to one-line output

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ track.
 **Flags**
 - `--one-line` - show playing data in one line (works well with status bars)
 - `--no-progress` - hide progress bar in one line mode
+- `-s, --scroll int` - scroll the output string if greater than n characters

--- a/cmd/player/player.go
+++ b/cmd/player/player.go
@@ -26,11 +26,13 @@ func init() {
 
 	playerCmd.Flags().BoolP("oneline", "o", false, "Output playback data on one line")
 	playerCmd.Flags().BoolP("no-progress", "", false, "Do not include progress bar")
+	playerCmd.Flags().IntP("scroll", "s", 0, "Scroll the output string if greater than n characters")
 }
 
 func spotifyPlayer(cmd *cobra.Command, args []string) {
 	oneLine, _ := cmd.Flags().GetBool("one-line")
 	noProgress, _ := cmd.Flags().GetBool("no-progress")
+	scroll, _ := cmd.Flags().GetInt("scroll")
 
 	token, err := connect.LoadOAuthToken()
 	if err != nil {
@@ -39,7 +41,7 @@ func spotifyPlayer(cmd *cobra.Command, args []string) {
 	client := spotify.New(connect.Auth.Client(context.Background(), token))
 
 	if oneLine {
-		oneLineOutput(client, noProgress)
+		oneLineOutput(client, noProgress, scroll)
 	}
 
 	p := bubbletea.NewProgram(model{
@@ -127,7 +129,7 @@ func (m model) View() string {
 			Foreground(lipgloss.Color("10")).
 			Bold(true).
 			Align(lipgloss.Left).
-      Width(50).
+			Width(50).
 			Render("spotgo")+"\n"+
 			style.Render(
 				content),


### PR DESCRIPTION
This allows for the scrolling text to activate once our output string has extended a certain length. This will be mostly beneficial when using the one-line output in the TMUX status bar but also looks quite nice when using this on the command line.

I have removed the ANSI escape code as the string `[K` gets outputted in addition to the song information. I am assuming this is because TMUX is already clearing the line and doing it twice leaves over that string.



![Screen Recording 2025-01-21 at 9 25 48 AM](https://github.com/user-attachments/assets/74577cd8-eb23-4fc1-a17b-6d0a72be332f)

