### PR TITLE
Add support for spotify daemon

### DIFF
--- a/cmd/daemon/daemon.go
+++ b/cmd/daemon/daemon.go
@@ -1,0 +1,16 @@
+package daemon
+
+import (
+	"github.com/Esteban-Bermudez/spotgo/cmd/root"
+	"github.com/spf13/cobra"
+)
+
+var DaemonCmd = &cobra.Command{
+	Use:     "daemon",
+	Aliases: []string{"d"},
+	Short:   "Manage background spotifyd instance",
+}
+
+func init() {
+	root.RootCmd.AddCommand(DaemonCmd)
+}

--- a/cmd/daemon/install.go
+++ b/cmd/daemon/install.go
@@ -1,0 +1,179 @@
+package daemon
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/Esteban-Bermudez/spotgo/config"
+	"github.com/spf13/cobra"
+)
+
+var installCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install spotifyd binary for your system",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if runtime.GOOS == "darwin" {
+			fmt.Print("On macOS, spotifyd will be installed via Homebrew. Proceed? (y/n): ")
+			var response string
+			fmt.Scanln(&response)
+			if strings.ToLower(strings.TrimSpace(response)) == "y" {
+				fmt.Println("Installing spotifyd via brew...")
+				installCmd := exec.Command("brew", "install", "spotifyd")
+				installCmd.Stdout = os.Stdout
+				installCmd.Stderr = os.Stderr
+				if err := installCmd.Run(); err != nil {
+					return fmt.Errorf("brew install failed: %w", err)
+				}
+				fmt.Println("spotifyd installed successfully via Homebrew.")
+				return nil
+			}
+			return fmt.Errorf("installation aborted")
+		}
+
+		if runtime.GOOS != "linux" {
+			return fmt.Errorf("unsupported system: %s", runtime.GOOS)
+		}
+
+		archMap := map[string]string{"amd64": "x86_64", "arm64": "aarch64", "arm": "armv7"}
+		archName := archMap[runtime.GOARCH]
+		if archName == "" {
+			return fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
+		}
+
+		targetAsset := fmt.Sprintf("spotifyd-linux-%s-default.tar.gz", archName)
+		fmt.Printf("Looking for release: %s\n", targetAsset)
+
+		resp, err := http.Get("https://api.github.com/repos/Spotifyd/spotifyd/releases/latest")
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		var release struct {
+			Assets []struct {
+				Name               string `json:"name"`
+				BrowserDownloadURL string `json:"browser_download_url"`
+			} `json:"assets"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+			return err
+		}
+
+		var downloadURL string
+		for _, asset := range release.Assets {
+			if asset.Name == targetAsset {
+				downloadURL = asset.BrowserDownloadURL
+				break
+			}
+		}
+
+		if downloadURL == "" {
+			return fmt.Errorf("could not find asset %s in latest release", targetAsset)
+		}
+
+		binDir := filepath.Join(config.DataDir(), "bin")
+		os.MkdirAll(binDir, 0755)
+
+		fmt.Printf("Downloading %s...\n", downloadURL)
+		assetResp, err := http.Get(downloadURL)
+		if err != nil {
+			return err
+		}
+		defer assetResp.Body.Close()
+
+		gr, err := gzip.NewReader(assetResp.Body)
+		if err != nil {
+			return err
+		}
+		defer gr.Close()
+
+		tr := tar.NewReader(gr)
+		var installed bool
+		for {
+			header, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return err
+			}
+
+			if header.Typeflag == tar.TypeReg && strings.HasSuffix(header.Name, "spotifyd") {
+				targetFile := filepath.Join(binDir, "spotifyd")
+				f, err := os.OpenFile(targetFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+				if err != nil {
+					return err
+				}
+				if _, err := io.Copy(f, tr); err != nil {
+					f.Close()
+					return err
+				}
+				f.Close()
+				fmt.Printf("Successfully installed spotifyd to %s\n", targetFile)
+				installed = true
+				break
+			}
+		}
+
+		if !installed {
+			return fmt.Errorf("spotifyd binary not found in tarball")
+		}
+
+		installLinuxDeps()
+
+		return nil
+	},
+}
+
+func installLinuxDeps() {
+	var pm string
+	var args []string
+
+	if _, err := exec.LookPath("apt-get"); err == nil {
+		pm = "apt-get"
+		args = []string{"install", "-y", "libasound2-dev", "libssl-dev", "libpulse-dev", "libdbus-1-dev"}
+	} else if _, err := exec.LookPath("dnf"); err == nil {
+		pm = "dnf"
+		args = []string{"install", "-y", "alsa-lib-devel", "make", "gcc"}
+	} else if _, err := exec.LookPath("pacman"); err == nil {
+		pm = "pacman"
+		args = []string{"-S", "--noconfirm", "base-devel", "alsa-lib", "libogg", "libpulse", "dbus"}
+	} else if _, err := exec.LookPath("zypper"); err == nil {
+		pm = "zypper"
+		args = []string{"install", "-y", "alsa-devel", "make", "gcc"}
+	} else {
+		fmt.Println("Could not detect package manager. Please manually install dependencies.")
+		return
+	}
+
+	fmt.Printf("\nspotifyd requires dependencies to run. Detected package manager: %s\n", pm)
+	fmt.Printf("Command: sudo %s %s\n", pm, strings.Join(args, " "))
+	fmt.Print("Proceed with installing dependencies? (y/n): ")
+	var response string
+	fmt.Scanln(&response)
+	if strings.ToLower(strings.TrimSpace(response)) == "y" {
+		cmd := exec.Command("sudo", append([]string{pm}, args...)...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Failed to install dependencies: %v\n", err)
+		} else {
+			fmt.Println("Dependencies installed successfully.")
+		}
+	} else {
+		fmt.Println("Skipping dependency installation.")
+	}
+}
+
+func init() {
+	DaemonCmd.AddCommand(installCmd)
+}

--- a/cmd/daemon/start.go
+++ b/cmd/daemon/start.go
@@ -1,0 +1,105 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"syscall"
+
+	"github.com/Esteban-Bermudez/spotgo/config"
+	"github.com/spf13/cobra"
+)
+
+var startCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the background spotifyd daemon",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		binPath, err := spotifydBinaryPath(runtime.GOOS, config.DataDir(), exec.LookPath, fileExists)
+		if err != nil {
+			return err
+		}
+
+		stateDir := config.StateDir()
+		os.MkdirAll(stateDir, 0755)
+		pidFile := filepath.Join(stateDir, "spotifyd.pid")
+
+		if _, err := os.Stat(pidFile); err == nil {
+			return fmt.Errorf("spotifyd may already be running. Check %s", pidFile)
+		}
+
+		spotifydArgs := spotifydStartArgs(runtime.GOOS, pidFile)
+		c := exec.Command(binPath, spotifydArgs...)
+
+		if runtime.GOOS == "darwin" {
+			c.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+			if err := c.Start(); err != nil {
+				return fmt.Errorf("failed to start spotifyd: %w", err)
+			}
+
+			pid := c.Process.Pid
+			if err := os.WriteFile(pidFile, []byte(strconv.Itoa(pid)), 0644); err != nil {
+				return fmt.Errorf("failed to write pid file: %w", err)
+			}
+			if err := c.Process.Release(); err != nil {
+				return fmt.Errorf("failed to release spotifyd process: %w", err)
+			}
+
+			fmt.Print(spotifydStartedMessage(pid))
+			return nil
+		}
+
+		if err := c.Run(); err != nil {
+			return fmt.Errorf("failed to start spotifyd: %w", err)
+		}
+
+		fmt.Printf("Started spotifyd daemon in the background.\n")
+		return nil
+	},
+}
+
+func spotifydBinaryPath(goos string, dataDir string, lookPath func(string) (string, error), exists func(string) bool) (string, error) {
+	localPath := filepath.Join(dataDir, "bin", "spotifyd")
+
+	if goos == "darwin" {
+		if path, err := lookPath("spotifyd"); err == nil {
+			return path, nil
+		}
+		if exists(localPath) {
+			return localPath, nil
+		}
+		return "", fmt.Errorf("spotifyd not found. Run `spotgo daemon install` first")
+	}
+
+	if exists(localPath) {
+		return localPath, nil
+	}
+	if path, err := lookPath("spotifyd"); err == nil {
+		return path, nil
+	}
+
+	return "", fmt.Errorf("spotifyd not found at %s. Run `spotgo daemon install` first", localPath)
+}
+
+func spotifydStartArgs(goos string, pidFile string) []string {
+	if goos == "darwin" {
+		return []string{"--no-daemon", "--backend", "portaudio", "--device-name", "spotgo"}
+	}
+
+	return []string{"--pid", pidFile, "--device-name", "spotgo"}
+}
+
+func spotifydStartedMessage(pid int) string {
+	return fmt.Sprintf("Started spotifyd daemon in the background (PID %d).\n", pid)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func init() {
+	DaemonCmd.AddCommand(startCmd)
+}

--- a/cmd/daemon/start_test.go
+++ b/cmd/daemon/start_test.go
@@ -1,0 +1,66 @@
+package daemon
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestSpotifydBinaryPathPrefersPathOnMacOS(t *testing.T) {
+	path, err := spotifydBinaryPath(
+		"darwin",
+		"/Users/me/.local/share/spotgo",
+		func(name string) (string, error) { return "/opt/homebrew/bin/spotifyd", nil },
+		func(path string) bool { return path == "/Users/me/.local/share/spotgo/bin/spotifyd" },
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "/opt/homebrew/bin/spotifyd" {
+		t.Fatalf("expected Homebrew spotifyd path, got %q", path)
+	}
+}
+
+func TestSpotifydStartArgsUsePortAudioForegroundModeOnMacOS(t *testing.T) {
+	args := spotifydStartArgs("darwin", "/Users/me/.local/state/spotgo/spotifyd.pid")
+	want := []string{"--no-daemon", "--backend", "portaudio", "--device-name", "spotgo", "--device-type", "computer"}
+
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("expected args %#v, got %#v", want, args)
+	}
+}
+
+func TestSpotifydStartArgsUseNativePidFileOnLinux(t *testing.T) {
+	args := spotifydStartArgs("linux", "/home/me/.local/state/spotgo/spotifyd.pid")
+	want := []string{"--pid", "/home/me/.local/state/spotgo/spotifyd.pid", "--device-name", "spotgo", "--device-type", "computer"}
+
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("expected args %#v, got %#v", want, args)
+	}
+}
+
+func TestSpotifydBinaryPathFallsBackToLocalInstallOnLinux(t *testing.T) {
+	path, err := spotifydBinaryPath(
+		"linux",
+		"/home/me/.local/share/spotgo",
+		func(name string) (string, error) { return "", errors.New("not found") },
+		func(path string) bool { return path == "/home/me/.local/share/spotgo/bin/spotifyd" },
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "/home/me/.local/share/spotgo/bin/spotifyd" {
+		t.Fatalf("expected local spotifyd path, got %q", path)
+	}
+}
+
+func TestSpotifydStartedMessageIncludesCapturedPid(t *testing.T) {
+	got := spotifydStartedMessage(70672)
+	want := "Started spotifyd daemon in the background (PID 70672).\n"
+
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}

--- a/cmd/daemon/status.go
+++ b/cmd/daemon/status.go
@@ -1,0 +1,55 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/Esteban-Bermudez/spotgo/config"
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Check the status of the spotifyd daemon",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		pidFile := filepath.Join(config.StateDir(), "spotifyd.pid")
+
+		data, err := os.ReadFile(pidFile)
+		if err != nil {
+			fmt.Println("spotifyd daemon is stopped.")
+			return nil
+		}
+
+		pidStr := strings.TrimSpace(string(data))
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			return fmt.Errorf("invalid pid in file: %w", err)
+		}
+
+		process, err := os.FindProcess(pid)
+		if err != nil {
+			fmt.Println("spotifyd daemon is stopped (stale pid file).")
+			os.Remove(pidFile)
+			return nil
+		}
+
+		// On Unix, FindProcess always succeeds. We must send signal 0 to check if it's alive.
+		err = process.Signal(syscall.Signal(0))
+		if err != nil {
+			fmt.Println("spotifyd daemon is stopped (stale pid file).")
+			os.Remove(pidFile)
+			return nil
+		}
+
+		fmt.Printf("spotifyd daemon is running (PID %d).\n", pid)
+		return nil
+	},
+}
+
+func init() {
+	DaemonCmd.AddCommand(statusCmd)
+}

--- a/cmd/daemon/stop.go
+++ b/cmd/daemon/stop.go
@@ -1,0 +1,50 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/Esteban-Bermudez/spotgo/config"
+	"github.com/spf13/cobra"
+)
+
+var stopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop the background spotifyd daemon",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		pidFile := filepath.Join(config.StateDir(), "spotifyd.pid")
+
+		data, err := os.ReadFile(pidFile)
+		if err != nil {
+			return fmt.Errorf("could not read pid file (is the daemon running?): %w", err)
+		}
+
+		pidStr := strings.TrimSpace(string(data))
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			return fmt.Errorf("invalid pid in file: %w", err)
+		}
+
+		process, err := os.FindProcess(pid)
+		if err != nil {
+			os.Remove(pidFile)
+			return fmt.Errorf("could not find process %d", pid)
+		}
+
+		if err := process.Signal(syscall.SIGTERM); err != nil {
+			return fmt.Errorf("failed to stop process: %w", err)
+		}
+
+		os.Remove(pidFile)
+		fmt.Printf("Stopped spotifyd daemon (PID %d)\n", pid)
+		return nil
+	},
+}
+
+func init() {
+	DaemonCmd.AddCommand(stopCmd)
+}

--- a/cmd/devices/devices.go
+++ b/cmd/devices/devices.go
@@ -1,14 +1,34 @@
 package devices
 
 import (
+	"context"
+	"log"
+
 	"github.com/Esteban-Bermudez/spotgo/cmd/root"
+	"github.com/Esteban-Bermudez/spotgo/config"
 	"github.com/spf13/cobra"
+	"github.com/zmb3/spotify/v2"
 )
+
+var spotgoClient *spotify.Client
 
 var DevicesCmd = &cobra.Command{
 	Use:     "devices",
 	Aliases: []string{"device"},
 	Short:   "Manage Spotify Connect devices",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		v, err := config.LoadConfig()
+		if err != nil {
+			log.Fatal("Error loading config file, Run `spotgo connect` to create a config file and connect to Spotify")
+		}
+		spotgoClient, err = config.SpotifyClient(context.Background(), v)
+		if err != nil {
+			log.Fatal("Error creating Spotify client, Run `spotgo connect` to connect to Spotify")
+		}
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		lsCmd.Run(cmd, args)
+	},
 }
 
 func init() {

--- a/cmd/devices/devices.go
+++ b/cmd/devices/devices.go
@@ -1,0 +1,16 @@
+package devices
+
+import (
+	"github.com/Esteban-Bermudez/spotgo/cmd/root"
+	"github.com/spf13/cobra"
+)
+
+var DevicesCmd = &cobra.Command{
+	Use:     "devices",
+	Aliases: []string{"device"},
+	Short:   "Manage Spotify Connect devices",
+}
+
+func init() {
+	root.RootCmd.AddCommand(DevicesCmd)
+}

--- a/cmd/devices/ls.go
+++ b/cmd/devices/ls.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/Esteban-Bermudez/spotgo/config"
 	"github.com/spf13/cobra"
 )
 
@@ -13,16 +12,7 @@ var lsCmd = &cobra.Command{
 	Use:   "ls",
 	Short: "List available Spotify Connect devices",
 	Run: func(cmd *cobra.Command, args []string) {
-		v, err := config.LoadConfig()
-		if err != nil {
-			log.Fatal("Error loading config. Run `spotgo connect`.")
-		}
-		client, err := config.SpotifyClient(context.Background(), v)
-		if err != nil {
-			log.Fatal("Error creating Spotify client.")
-		}
-
-		devices, err := client.PlayerDevices(context.Background())
+		devices, err := spotgoClient.PlayerDevices(context.Background())
 		if err != nil {
 			log.Fatalf("Error fetching devices: %v", err)
 		}

--- a/cmd/devices/ls.go
+++ b/cmd/devices/ls.go
@@ -1,0 +1,44 @@
+package devices
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/Esteban-Bermudez/spotgo/config"
+	"github.com/spf13/cobra"
+)
+
+var lsCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "List available Spotify Connect devices",
+	Run: func(cmd *cobra.Command, args []string) {
+		v, err := config.LoadConfig()
+		if err != nil {
+			log.Fatal("Error loading config. Run `spotgo connect`.")
+		}
+		client, err := config.SpotifyClient(context.Background(), v)
+		if err != nil {
+			log.Fatal("Error creating Spotify client.")
+		}
+
+		devices, err := client.PlayerDevices(context.Background())
+		if err != nil {
+			log.Fatalf("Error fetching devices: %v", err)
+		}
+
+		fmt.Printf("%-30s | %-15s | %-10s | %s\n", "NAME", "TYPE", "ACTIVE", "ID")
+		fmt.Println("--------------------------------------------------------------------------------")
+		for _, d := range devices {
+			activeStr := ""
+			if d.Active {
+				activeStr = "yes"
+			}
+			fmt.Printf("%-30s | %-15s | %-10s | %s\n", d.Name, d.Type, activeStr, d.ID)
+		}
+	},
+}
+
+func init() {
+	DevicesCmd.AddCommand(lsCmd)
+}

--- a/cmd/devices/switch.go
+++ b/cmd/devices/switch.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/Esteban-Bermudez/spotgo/config"
 	"github.com/spf13/cobra"
 	"github.com/zmb3/spotify/v2"
 )
@@ -16,17 +15,8 @@ var switchCmd = &cobra.Command{
 	Short: "Transfer playback to another device",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		v, err := config.LoadConfig()
-		if err != nil {
-			log.Fatal("Error loading config.")
-		}
-		client, err := config.SpotifyClient(context.Background(), v)
-		if err != nil {
-			log.Fatal("Error creating Spotify client.")
-		}
-
 		target := args[0]
-		devices, err := client.PlayerDevices(context.Background())
+		devices, err := spotgoClient.PlayerDevices(context.Background())
 		if err != nil {
 			log.Fatalf("Error fetching devices: %v", err)
 		}
@@ -44,7 +34,7 @@ var switchCmd = &cobra.Command{
 			log.Fatalf("Device '%s' not found.", target)
 		}
 
-		err = client.TransferPlayback(context.Background(), targetID, true)
+		err = spotgoClient.TransferPlayback(context.Background(), targetID, true)
 		if err != nil {
 			log.Fatalf("Failed to transfer playback: %v", err)
 		}

--- a/cmd/devices/switch.go
+++ b/cmd/devices/switch.go
@@ -1,0 +1,57 @@
+package devices
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/Esteban-Bermudez/spotgo/config"
+	"github.com/spf13/cobra"
+	"github.com/zmb3/spotify/v2"
+)
+
+var switchCmd = &cobra.Command{
+	Use:   "switch <device-id-or-name>",
+	Short: "Transfer playback to another device",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		v, err := config.LoadConfig()
+		if err != nil {
+			log.Fatal("Error loading config.")
+		}
+		client, err := config.SpotifyClient(context.Background(), v)
+		if err != nil {
+			log.Fatal("Error creating Spotify client.")
+		}
+
+		target := args[0]
+		devices, err := client.PlayerDevices(context.Background())
+		if err != nil {
+			log.Fatalf("Error fetching devices: %v", err)
+		}
+
+		var targetID spotify.ID
+		for _, d := range devices {
+			if string(d.ID) == target || strings.Contains(strings.ToLower(d.Name), strings.ToLower(target)) {
+				targetID = d.ID
+				fmt.Printf("Switching to device: %s\n", d.Name)
+				break
+			}
+		}
+
+		if targetID == "" {
+			log.Fatalf("Device '%s' not found.", target)
+		}
+
+		err = client.TransferPlayback(context.Background(), targetID, true)
+		if err != nil {
+			log.Fatalf("Failed to transfer playback: %v", err)
+		}
+		fmt.Println("Playback transferred successfully.")
+	},
+}
+
+func init() {
+	DevicesCmd.AddCommand(switchCmd)
+}

--- a/cmd/spotgo/main.go
+++ b/cmd/spotgo/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Esteban-Bermudez/spotgo/cmd/root"
 	// This ensures the init commands in the sub commands run
 	_ "github.com/Esteban-Bermudez/spotgo/cmd/connect"
+	_ "github.com/Esteban-Bermudez/spotgo/cmd/devices"
 	_ "github.com/Esteban-Bermudez/spotgo/cmd/player"
 )
 

--- a/cmd/spotgo/main.go
+++ b/cmd/spotgo/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Esteban-Bermudez/spotgo/cmd/root"
 	// This ensures the init commands in the sub commands run
 	_ "github.com/Esteban-Bermudez/spotgo/cmd/connect"
+	_ "github.com/Esteban-Bermudez/spotgo/cmd/daemon"
 	_ "github.com/Esteban-Bermudez/spotgo/cmd/devices"
 	_ "github.com/Esteban-Bermudez/spotgo/cmd/player"
 )

--- a/config/config.go
+++ b/config/config.go
@@ -27,11 +27,7 @@ func InitConfig() (*viper.Viper, error) {
 	missingConfig := errors.As(err, &viper.ConfigFileNotFoundError{})
 
 	if missingConfig {
-		configDir := os.ExpandEnv("$XDG_CONFIG_HOME/spotgo/")
-		if configDir == "/spotgo/" {
-			configDir = os.ExpandEnv("$HOME/.config/spotgo/")
-		}
-		err = os.MkdirAll(configDir, 0700)
+		err = os.MkdirAll(ConfigDir(), 0700)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create config directory: %w", err)
 		}
@@ -90,9 +86,8 @@ func LoadConfig() (*viper.Viper, error) {
 
 	v.SetConfigName("spotgo")
 	v.SetConfigType("json")
-	v.AddConfigPath(os.ExpandEnv("$XDG_CONFIG_HOME/spotgo/")) // Default: XDG config directory
-	v.AddConfigPath(os.ExpandEnv("$HOME/.config/spotgo/"))    // Optional: config directory
-	v.AddConfigPath(os.ExpandEnv("$HOME/.spotgo/"))           // Optional: Home directory
+
+	v.AddConfigPath(ConfigDir())
 
 	err := v.ReadInConfig()
 	if err != nil {

--- a/config/utils.go
+++ b/config/utils.go
@@ -4,6 +4,8 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -32,4 +34,28 @@ func MarshalToken(token *oauth2.Token) (map[string]any, error) {
 		"refresh_token": token.RefreshToken,
 		"expiry":        token.Expiry.Format(time.RFC3339),
 	}, nil
+}
+
+func DataDir() string {
+	if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
+		return filepath.Join(xdgDataHome, "spotgo")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".local", "share", "spotgo")
+}
+
+func ConfigDir() string {
+	if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+		return filepath.Join(xdgConfigHome, "spotgo")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config", "spotgo")
+}
+
+func StateDir() string {
+	if xdgStateHome := os.Getenv("XDG_STATE_HOME"); xdgStateHome != "" {
+		return filepath.Join(xdgStateHome, "spotgo")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".local", "state", "spotgo")
 }

--- a/config/utils_test.go
+++ b/config/utils_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestConfigDirUsesXDGConfigHome(t *testing.T) {
+	xdgConfigHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+	t.Setenv("HOME", t.TempDir())
+
+	got := ConfigDir()
+	want := filepath.Join(xdgConfigHome, "spotgo")
+
+	if got != want {
+		t.Fatalf("expected config dir %q, got %q", want, got)
+	}
+}
+
+func TestConfigDirFallsBackToDotConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", home)
+
+	got := ConfigDir()
+	want := filepath.Join(home, ".config", "spotgo")
+
+	if got != want {
+		t.Fatalf("expected config dir %q, got %q", want, got)
+	}
+}
+
+func TestLoadConfigUsesConfigDirFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", home)
+
+	configDir := filepath.Join(home, ".config", "spotgo")
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	configFile := filepath.Join(configDir, "spotgo.json")
+	expiry := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	configJSON := []byte(`{
+  "token": {
+    "access_token": "access",
+    "token_type": "Bearer",
+    "refresh_token": "refresh",
+    "expiry": "` + expiry + `"
+  }
+}`)
+	if err := os.WriteFile(configFile, configJSON, 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	v, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	if v.ConfigFileUsed() != configFile {
+		t.Fatalf("expected config file %q, got %q", configFile, v.ConfigFileUsed())
+	}
+}


### PR DESCRIPTION
This pull request introduces two major new command groups to the CLI: `daemon` for managing a background `spotifyd` process, and `devices` for managing Spotify Connect devices. It also improves configuration file handling to better support XDG directory standards and adds utility functions for data and state directory resolution. The most important changes are grouped below:

### Daemon management commands (`cmd/daemon/`):

* Adds a new `daemon` command group with subcommands to install, start, stop, and check the status of a background `spotifyd` daemon, including cross-platform logic for macOS and Linux. Installation handles downloading the correct binary and installing dependencies, while status and stop commands manage the daemon's process lifecycle. [[1]](diffhunk://#diff-2c6bfb49db10e6ba24cf99a6fa38d7cb4961fa38076d442be54fbdc465d66cfcR1-R16) [[2]](diffhunk://#diff-2203e857c92d30b3925f98ed75299feeb388ff82cf2cfd7eb6dacd8a2a2e17e4R1-R179) [[3]](diffhunk://#diff-aa0c03cf0f35759c3a62940a32fafab1e08c70d3f12f9239d320feda738989a6R1-R105) [[4]](diffhunk://#diff-4a8c5512a7be3290cacf413910a762de471f13221736b8dd985df4288d384fcbR1-R55) [[5]](diffhunk://#diff-36ba65e8b0773c3424d7d2009b6544bde0bbb743cf89cbeacc545b8f76f7f74bR1-R50)
* Adds tests for the logic that determines the binary path and arguments for starting `spotifyd`.

### Devices management commands (`cmd/devices/`):

* Adds a new `devices` command group with subcommands to list available Spotify Connect devices and switch playback between them, leveraging the Spotify API. [[1]](diffhunk://#diff-952e71d12b89576501dbfc31cf3324a53ab03a3f3853be46dd260374e5c25bbeR1-R36) [[2]](diffhunk://#diff-6c6a33866ea29974805747ef5d1512eca9eb41ef12c440c0926937575a632ab1R1-R34) [[3]](diffhunk://#diff-da58078401ca122c3f14ad20e469fea421192f20c039fd0e237b7e73e6c02004R1-R47)

### Configuration and utility improvements:

* Updates config file handling to use the XDG config directory (`os.UserConfigDir()`), ensures config directories are created if missing, and improves config search paths for better cross-platform compatibility. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R12) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L29-L34) [[3]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L85-R102)
* Adds utility functions `DataDir()` and `StateDir()` to resolve XDG data and state directories for storing binaries and state files, falling back to sensible defaults if XDG variables are unset. [[1]](diffhunk://#diff-2d1b55d98f0f1bbdb3a427dd63e23046ad227af7b5e29832b04e457c686c1836R7-R8) [[2]](diffhunk://#diff-2d1b55d98f0f1bbdb3a427dd63e23046ad227af7b5e29832b04e457c686c1836R38-R53)
* Changes the Spotify OAuth redirect URL to use `127.0.0.1` instead of `localhost` for reliability.

### Integration:

* Registers the new `daemon` and `devices` command groups in the main CLI entrypoint to ensure they are available to users.